### PR TITLE
feature/section-13-1

### DIFF
--- a/src/main/java/hello/aop/internalcall/CallServiceV0.java
+++ b/src/main/java/hello/aop/internalcall/CallServiceV0.java
@@ -1,0 +1,32 @@
+package hello.aop.internalcall;
+
+import hello.aop.internalcall.aop.CallLogAspect;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+/**
+ * {@link CallLogAspect}에 의해 external, internal 메소드에 대한 프록시가 생성된다.
+ */
+@Slf4j
+@Component
+public class CallServiceV0 {
+
+    /**
+     * target = CallServiceV0
+     * <p>
+     * target#external()안에서 target#internal()를 호출할 경우 (내부 호출)
+     * target#internal()에 대해 AOP가 적용되지 않아 advice가 호출되지 않는다.
+     * <p>
+     * 즉,
+     * 프록시를 통해 internal을 호출할 경우에만 AOP가 적용된다.
+     * target(this) 내에서 internal을 호출한다면 AOP가 적용되지 않는다.
+     */
+    public void external() {
+        log.info("call external");
+        internal(); //내부 메서드 호출(this.internal())
+    }
+
+    public void internal() {
+        log.info("call internal");
+    }
+}

--- a/src/main/java/hello/aop/internalcall/CallServiceV1.java
+++ b/src/main/java/hello/aop/internalcall/CallServiceV1.java
@@ -1,0 +1,36 @@
+package hello.aop.internalcall;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CallServiceV1 {
+
+    private CallServiceV1 callServiceV1;
+
+    /**
+     * constructor로 주입하면 circular injection error 발생하므로
+     * setter를 통해 주입받도록 해야 한다.
+     */
+    @Autowired
+    public void setCallServiceV1(CallServiceV1 callServiceV1) {
+        this.callServiceV1 = callServiceV1;
+    }
+
+    /**
+     * target#external()에서 this.internal()이 아니라
+     * callServiceV1.internal()을 호출한다.
+     * <p>
+     * 프록시를 통해 호출한 callServiceV1.internal()에 AOP가 적용된다.
+     */
+    public void external() {
+        log.info("call external");
+        callServiceV1.internal(); //외부 메서드 호출
+    }
+
+    public void internal() {
+        log.info("call internal");
+    }
+}

--- a/src/main/java/hello/aop/internalcall/CallServiceV2.java
+++ b/src/main/java/hello/aop/internalcall/CallServiceV2.java
@@ -1,0 +1,39 @@
+package hello.aop.internalcall;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationContext;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class CallServiceV2 {
+
+    /**
+     * ApplicationContext을 주입받아 CallServiceV2의 bean을 지연주입 받는 방법도 있다.
+     * 하지만 매우 무식하다.
+     */
+    // private final ApplicationContext applicationContext;
+
+
+    /**
+     * ObjectProvider을 통해 CallServiceV2을 지연(Lazy) 조회할 수 있다.
+     */
+    private final ObjectProvider<CallServiceV2> callServiceProvider;
+
+    public CallServiceV2(ObjectProvider<CallServiceV2> callServiceProvider) {
+        this.callServiceProvider = callServiceProvider;
+    }
+
+    public void external() {
+        log.info("call external");
+        // CallServiceV2 callServiceV2 = applicationContext.getBean(CallServiceV2.class);
+        CallServiceV2 callServiceV2 = callServiceProvider.getObject(); // getObject 시점에 조회된다. -> 지연 조회
+        callServiceV2.internal(); //외부 메서드 호출
+    }
+
+    public void internal() {
+        log.info("call internal");
+    }
+}

--- a/src/main/java/hello/aop/internalcall/CallServiceV3.java
+++ b/src/main/java/hello/aop/internalcall/CallServiceV3.java
@@ -1,0 +1,23 @@
+package hello.aop.internalcall;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.stereotype.Component;
+
+/**
+ * 구조를 변경(분리)
+ */
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class CallServiceV3 {
+
+    private final InternalService internalService;
+
+    public void external() {
+        log.info("call external");
+        internalService.internal(); //외부 메서드 호출
+    }
+
+}

--- a/src/main/java/hello/aop/internalcall/InternalService.java
+++ b/src/main/java/hello/aop/internalcall/InternalService.java
@@ -1,0 +1,14 @@
+package hello.aop.internalcall;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class InternalService {
+
+    public void internal() {
+        log.info("call internal");
+    }
+
+}

--- a/src/main/java/hello/aop/internalcall/aop/CallLogAspect.java
+++ b/src/main/java/hello/aop/internalcall/aop/CallLogAspect.java
@@ -1,0 +1,16 @@
+package hello.aop.internalcall.aop;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+@Slf4j
+@Aspect
+public class CallLogAspect {
+
+    @Before("execution(* hello.aop.internalcall..*.*(..))")
+    public void doLog(JoinPoint joinPoint) {
+        log.info("aop={}", joinPoint.getSignature());
+    }
+}

--- a/src/test/java/hello/aop/internalcall/CallServiceV0Test.java
+++ b/src/test/java/hello/aop/internalcall/CallServiceV0Test.java
@@ -1,0 +1,36 @@
+package hello.aop.internalcall;
+
+import hello.aop.internalcall.aop.CallLogAspect;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+@Import(CallLogAspect.class)
+@SpringBootTest
+class CallServiceV0Test {
+
+    @Autowired
+    CallServiceV0 callServiceV0;
+
+    /**
+     * external 메소드에서만 AOP가 적용되고,
+     * external 메소드 내부에서 호출한 internal 메소드에는 AOP가 적용되지 않는다.
+     */
+    @Test
+    void external() {
+        callServiceV0.external();
+    }
+
+    /**
+     * 외부에서 internal 메소드를 호출하면 AOP가 적용된다. 왜냐면 프록시를 거치지 때문이다.
+     */
+    @Test
+    void internal() {
+        callServiceV0.internal();
+    }
+}

--- a/src/test/java/hello/aop/internalcall/CallServiceV1Test.java
+++ b/src/test/java/hello/aop/internalcall/CallServiceV1Test.java
@@ -1,0 +1,23 @@
+package hello.aop.internalcall;
+
+import hello.aop.internalcall.aop.CallLogAspect;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+@Import(CallLogAspect.class)
+@SpringBootTest
+class CallServiceV1Test {
+
+    @Autowired
+    CallServiceV1 callServiceV1;
+
+    @Test
+    void external() {
+        callServiceV1.external();
+    }
+
+}

--- a/src/test/java/hello/aop/internalcall/CallServiceV2Test.java
+++ b/src/test/java/hello/aop/internalcall/CallServiceV2Test.java
@@ -1,0 +1,23 @@
+package hello.aop.internalcall;
+
+import hello.aop.internalcall.aop.CallLogAspect;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+@Import(CallLogAspect.class)
+@SpringBootTest
+class CallServiceV2Test {
+
+    @Autowired
+    CallServiceV2 callServiceV2;
+
+    @Test
+    void external() {
+        callServiceV2.external();
+    }
+
+}

--- a/src/test/java/hello/aop/internalcall/CallServiceV3Test.java
+++ b/src/test/java/hello/aop/internalcall/CallServiceV3Test.java
@@ -1,0 +1,23 @@
+package hello.aop.internalcall;
+
+import hello.aop.internalcall.aop.CallLogAspect;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+@Import(CallLogAspect.class)
+@SpringBootTest
+class CallServiceV3Test {
+
+    @Autowired
+    CallServiceV3 callServiceV3;
+
+    @Test
+    void external() {
+        callServiceV3.external();
+    }
+
+}


### PR DESCRIPTION
# 프록시 내부 호출 문제

스프링은 프록시 방식의 AOP를 사용하므로, AOP를 적용하기 위해서 프록시를 통해 target(대상 객체)를 호출해야 한다.
> 만약 프록시를 거치지 않고 target을 호출하면 AOP가 적용되지 않고, advice도 호출되지 않는다.

![image](https://github.com/StudyForBetterLife/Aop/assets/44316546/72b6ec60-c678-4bfe-9d4c-3210ebf40469)
