### PR TITLE
feature/section-13-2

### DIFF
--- a/src/test/java/hello/aop/proxyvs/CglibProxyDITest.java
+++ b/src/test/java/hello/aop/proxyvs/CglibProxyDITest.java
@@ -1,0 +1,29 @@
+package hello.aop.proxyvs;
+
+import hello.aop.member.MemberService;
+import hello.aop.member.MemberServiceImpl;
+import hello.aop.proxyvs.code.ProxyDIAspect;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+@SpringBootTest(properties = {"spring.aop.proxy-target-class=true"}) //CGLIB 프록시
+@Import(ProxyDIAspect.class)
+public class CglibProxyDITest {
+
+    @Autowired
+    MemberService memberService; // interface를 주입
+
+    @Autowired
+    MemberServiceImpl memberServiceImpl; // 구현 클래스를 주입
+
+    @Test
+    void go() {
+        log.info("memberService class={}", memberService.getClass());
+        log.info("memberServiceImpl class={}", memberServiceImpl.getClass());
+        memberServiceImpl.hello("hello");
+    }
+}

--- a/src/test/java/hello/aop/proxyvs/JdkProxyDITest.java
+++ b/src/test/java/hello/aop/proxyvs/JdkProxyDITest.java
@@ -1,0 +1,33 @@
+package hello.aop.proxyvs;
+
+import hello.aop.member.MemberService;
+import hello.aop.member.MemberServiceImpl;
+import hello.aop.proxyvs.code.ProxyDIAspect;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Import;
+
+@Slf4j
+@SpringBootTest(properties = {"spring.aop.proxy-target-class=false"}) //JDK 동적 프록시
+@Import(ProxyDIAspect.class)
+public class JdkProxyDITest {
+
+    @Autowired
+    MemberService memberService; // interface를 주입
+
+    /**
+     * MemberService의 구현 클래스의 bean 주입받을 때,
+     * UnsatisfiedDependencyException 예외가 발생한다
+     */
+    @Autowired
+    MemberServiceImpl memberServiceImpl; // 구현 클래스를 주입
+
+    @Test
+    void go() {
+        log.info("memberService class={}", memberService.getClass());
+        log.info("memberServiceImpl class={}", memberServiceImpl.getClass());
+        memberServiceImpl.hello("hello");
+    }
+}

--- a/src/test/java/hello/aop/proxyvs/ProxyCastingTest.java
+++ b/src/test/java/hello/aop/proxyvs/ProxyCastingTest.java
@@ -1,0 +1,44 @@
+package hello.aop.proxyvs;
+
+import hello.aop.member.MemberService;
+import hello.aop.member.MemberServiceImpl;
+import lombok.extern.slf4j.Slf4j;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.aop.framework.ProxyFactory;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@Slf4j
+public class ProxyCastingTest {
+
+    @Test
+    void jdkProxy() {
+        MemberServiceImpl target = new MemberServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setProxyTargetClass(false); //JDK 동적 프록시
+
+        //프록시를 인터페이스로 캐스팅 성공
+        MemberService memberServiceProxy = (MemberService) proxyFactory.getProxy();
+
+        //JDK 동적 프록시를 구현 클래스로 캐스팅 시도 실패, ClassCastException 예외 발생
+        assertThrows(ClassCastException.class, () -> {
+            MemberServiceImpl castingMemberService = (MemberServiceImpl) memberServiceProxy;
+        });
+    }
+
+    @Test
+    void cglibProxy() {
+        MemberServiceImpl target = new MemberServiceImpl();
+        ProxyFactory proxyFactory = new ProxyFactory(target);
+        proxyFactory.setProxyTargetClass(true); //CGLIB 프록시
+
+        //프록시를 인터페이스로 캐스팅 성공
+        MemberService memberServiceProxy = (MemberService) proxyFactory.getProxy();
+
+        log.info("proxy class={}", memberServiceProxy.getClass());
+
+        //CGLIB 프록시를 구현 클래스로 캐스팅 시도 성공
+        MemberServiceImpl castingMemberService = (MemberServiceImpl) memberServiceProxy;
+    }
+}

--- a/src/test/java/hello/aop/proxyvs/code/ProxyDIAspect.java
+++ b/src/test/java/hello/aop/proxyvs/code/ProxyDIAspect.java
@@ -1,0 +1,16 @@
+package hello.aop.proxyvs.code;
+
+import lombok.extern.slf4j.Slf4j;
+import org.aspectj.lang.JoinPoint;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Before;
+
+@Slf4j
+@Aspect
+public class ProxyDIAspect {
+
+    @Before("execution(* hello.aop..*.*(..))")
+    public void doTrace(JoinPoint joinPoint) {
+        log.info("[proxyDIAdvice] {}", joinPoint.getSignature());
+    }
+}


### PR DESCRIPTION
# 프록시 기술의 한계 : 타입 캐스팅

 ## jdk proxy
![image](https://github.com/StudyForBetterLife/Aop/assets/44316546/409414e2-5d12-4d1e-9823-e14c1ca20892)

jdk proxy의 타입캐스
![image](https://github.com/StudyForBetterLife/Aop/assets/44316546/04faa1ae-4db5-4b6c-891f-ad461d7b5d74)

JDK Proxy는 MemberService 로 캐스팅은 가능하지만 MemberServiceImpl 이 어떤 것인지 전혀 알지 못한다. 
따라서 MemberServiceImpl 타입으로는 캐스팅이 불가능하다

> JDK 동적 프록시는 대상 객체인 MemberServiceImpl 로 캐스팅 할 수 없다.

## cglib proxy
![image](https://github.com/StudyForBetterLife/Aop/assets/44316546/446e6611-7969-4299-b0fd-b8f44eab69f9)

CGLIB 프록시 캐스팅
![image](https://github.com/StudyForBetterLife/Aop/assets/44316546/37c61849-2324-4f1b-b61a-8f24410a3b20)

CGLIB Proxy는 MemberServiceImpl 구체 클래스를 기반으로 생성된 프록시이다. 
따라서 CGLIB Proxy는 MemberServiceImpl 은 물론이고, MemberServiceImpl 이 구현한 인터페이스인 MemberService 로도 캐스팅 할 수 있다

> CGLIB 프록시는 대상 객체인 MemberServiceImpl 로 캐스팅 할 수 있다

## 타입 캐스팅 문제를 언급한 이유

의존관계 주입시에 jdk proxy의 경우 타입 캐스팅 문제가 발생한다